### PR TITLE
Disable limiter

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -83,8 +83,8 @@ const limiter = rateLimit({
   },
 });
 
-// apply to all requests
-app.use(limiter);
+// apply to all requests. Commented out to avoid rate-limit conflicts. See issue #137
+// app.use(limiter);
 
 const releaseCache = new ReleaseCache();
 


### PR DESCRIPTION
Disabled the API rate limit to avoid conflicting with Cloudflare request origins. See issue #137 on pcsx2-neet-it.