### PR TITLE
Properly parse `.tar.gz` assets

### DIFF
--- a/models/ReleaseCache.ts
+++ b/models/ReleaseCache.ts
@@ -156,7 +156,7 @@ function gatherReleaseAssets(
 
   for (let i = 0; i < release.assets.length; i++) {
     const asset = release.assets[i];
-    const assetComponents = path.parse(asset.name).name.split("-");
+    const assetComponents = path.parse(asset.name).name.replace(/\.[.a-zA-Z]+$/, "").split("-");
     if (assetComponents.length < 3) {
       log.warn("invalid release asset naming", {
         isLegacy: legacy,


### PR DESCRIPTION
Removes all extensions instead of just the last one before getting the component list, where "extension" is defined as a dot followed by any number of letters (but not numbers so we don't think version numbers are part of extensions)

Note: Untested